### PR TITLE
Add more descriptive response annotations

### DIFF
--- a/src/vecsync/cli.py
+++ b/src/vecsync/cli.py
@@ -19,7 +19,7 @@ def files():
 
     cprint(f"Files in store {store.name}:", "green")
     for file in files:
-        cprint(f" - {file}", "yellow")
+        cprint(f" - {file.name}", "yellow")
 
 
 @click.command()

--- a/src/vecsync/store/base.py
+++ b/src/vecsync/store/base.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class StoredFile(BaseModel):
+    id: str
+    name: str

--- a/src/vecsync/store/openai.py
+++ b/src/vecsync/store/openai.py
@@ -1,3 +1,4 @@
+from vecsync.store.base import StoredFile
 from openai import OpenAI
 from pathlib import Path
 from pydantic import BaseModel
@@ -34,9 +35,9 @@ class OpenAiVectorStore:
 
         raise ValueError(f"Vector store with name {self.name} not found.")
 
-    def get_files(self):
+    def get_files(self) -> list[StoredFile]:
         files = self.client.files.list()
-        return [file.filename for file in files]
+        return [StoredFile(id=file.id, name=file.filename) for file in files]
 
     def get_or_create(self):
         try:


### PR DESCRIPTION
# Summary

This PR addresses issue #4 

Currently the chat outputs the raw OpenAI annotation responses such as `57:0†source`. This PR does the following:
1. Convert a reference ID to the corresponding filename
2. Create a unique index of file names from [1, N]
3. Replace the system references `57:0†source` with `[1]`
4. Add a reference list at the end of the response

Example CLI response
<img width="822" alt="image" src="https://github.com/user-attachments/assets/9af8340b-d663-4a16-bede-a4ec542b8830" />

Example Gradio response
<img width="566" alt="image" src="https://github.com/user-attachments/assets/489ac0e1-6c59-4c56-b1e7-6bd9504b4cfe" />
